### PR TITLE
fix some typos in enzyme_tut.jl

### DIFF
--- a/Enzyme/enzyme_tut.jl
+++ b/Enzyme/enzyme_tut.jl
@@ -76,7 +76,7 @@ end
 
 # ╔═╡ 651ab7be-2f87-4112-8304-ac8ecfbda5ff
 md"""
-Alternatively, One could numerically approximate the derivatives by applying the formula from the top with a small value of h (also referred to as epsilon).
+Alternatively, one could numerically approximate the derivatives by applying the formula from the top with a small value of h (also referred to as epsilon).
 
 for our relu function we might do something like the following
 """

--- a/Enzyme/enzyme_tut.jl
+++ b/Enzyme/enzyme_tut.jl
@@ -110,7 +110,7 @@ end
 md"""
 Finite differences seems to work decently well here, why use automatic differentiation?
 
-Let's try a function with more inputs and take the entire gradient (i.e. derivative wrt all inputs.)
+Let's try a function with more inputs and take the entire gradient (i.e. derivative with respect to all inputs.)
 """
 
 # ╔═╡ 63d9f6bc-4b65-4717-8d37-85e6f96dc4a3
@@ -484,7 +484,7 @@ A reverse-mode AD algorithm would often:
 
 The reason for the added complexity of reverse-mode is two-fold:
 * First, one must execute the program backwards. For programs with loops, branching, or nontrivial control flow, setting up this infrastructure may be non-trivial. 
-* Second, derivatives wrt input variables are accumulated (`+=`), rather than assigned (like forward-mode). This is because the derivative wrt to a variable that gets used multiple times is the sum of derivative contributions from each of its users.
+* Second, derivatives with respect to input variables are accumulated (`+=`). This is because the derivative with respect to to a variable that gets used multiple times is the sum of derivative contributions from each of its users.
 
 Let's look at our simple_mlp example, but do it by hand this time.
 """


### PR DESCRIPTION
I like this enzyme tutorial, and it does a good job introducing the basic concepts behind AD. I also really like that it's written with accessible prose (and it doesn't try to dive into unnecessarily complicated mathematical discussions about cotangent bundles and Gateaux derivatives like some other AD tutorials).

This PR fixes a few typos in this document, and tries to clarify the wording in a few other places.

--------

Note: I wasn't able to figure out how to actually render the static web page from this julia source file, so I didn't verify that changes to the LaTeX parts rendered correctly.